### PR TITLE
signing binaries on mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,13 +27,13 @@ To install the Quix CLI, users have multiple methods depending on their operatin
 - **Install Latest Version without Specifying Version:**
 
   ```bash
-  curl -fsSL https://github.com/quixio/quix-cli/raw/main/install.sh | bash
+  curl -fsSL https://github.com/quixio/quix-cli/raw/main/install.sh | sudo bash
   ```
   
 - **Install Specific Version:**
 
   ```bash
-  curl -fsSL https://github.com/quixio/quix-cli/raw/main/install.sh | bash -s -- -v={version}
+  curl -fsSL https://github.com/quixio/quix-cli/raw/main/install.sh | sudo bash -s -- -v={version}
   ```
 
 ### For Linux:

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,15 @@ get_os(){
     fi
 }
 
+sign_binary() {
+    os=$1
+    executable=$2
+    if [ "$os" == "osx" ]; then
+        echo "Signing '${executable}'"
+        codesign -s - "${executable}"
+    fi
+}
+
 # Parse arguments
 for i in "$@"; do
     case $i in
@@ -75,6 +84,8 @@ tar -xzf "${downloaded_file}" -C "${executable_folder}"
 
 exe="${executable_folder}/${exe_name}"
 chmod +x "${exe}"
+
+sign_binary "$os" "$exe"  # Sign the binary for macOS
 
 echo "[4/5] Cleaning '${downloaded_file}'"
 rm -f ${downloaded_file}


### PR DESCRIPTION
* Adding sudo for the mac scripts
* Adding ad hoc signature as osx-arm64 requires the binaries to be signed

Note: 
We are using an ad hoc signature, we may want to change this in the future.
This issue is also relevant https://github.com/dotnet/sdk/issues/34917.
