### PR TITLE
Quix-73484: Note descriptor v2.0 and link YAML 2.0 docs

### DIFF
--- a/docs/cli-quickstart.md
+++ b/docs/cli-quickstart.md
@@ -118,7 +118,7 @@ If you look at the initial `quix.yaml` file you'll see the following:
 # This file describes the data pipeline and configuration of resources of a Quix Project.
 
 metadata:
-  version: 1.0
+  version: 2.0
 
 # This section describes the Deployments of the data pipeline
 deployments: []
@@ -177,7 +177,7 @@ Now, view your `quix.yaml` file again to see how a deployment for each applicati
 # This file describes the data pipeline and configuration of resources of a Quix Project.
 
 metadata:
-  version: 1.0
+  version: 2.0
 
 # This section describes the Deployments of the data pipeline
 deployments:
@@ -186,8 +186,9 @@ deployments:
     deploymentType: Service
     version: latest
     resources:
-      cpu: 200
-      memory: 500
+      limits:
+        cpu: 200
+        memory: 500
       replicas: 1
     variables:
       - name: output
@@ -200,8 +201,9 @@ deployments:
     deploymentType: Service
     version: latest
     resources:
-      cpu: 200
-      memory: 500
+      limits:
+        cpu: 200
+        memory: 500
       replicas: 1
     variables:
       - name: input

--- a/docs/cli-reference/cloud/environments/sync.md
+++ b/docs/cli-reference/cloud/environments/sync.md
@@ -34,7 +34,7 @@ Given this `quix.yaml`:
 
 ```yaml
 metadata:
-  version: 1.0
+  version: 2.0
 
 deployments:
   - name: Starter Source
@@ -42,8 +42,9 @@ deployments:
     version: latest
     deploymentType: Job
     resources:
-      cpu: 100
-      memory: 100
+      limits:
+        cpu: 100
+        memory: 100
       replicas: 1
     variables:
       - name: output

--- a/docs/local-development/local-debug.md
+++ b/docs/local-development/local-debug.md
@@ -304,8 +304,9 @@ Your `quix.yaml` file will now contain the new variable you created:
     version: latest
     deploymentType: Service
     resources:
-      cpu: 200
-      memory: 800
+      limits:
+        cpu: 200
+        memory: 800
       replicas: 1
     variables:
       - name: input
@@ -345,8 +346,9 @@ This is helpful when you merge remote changes from git and the variable values h
     version: latest
     deploymentType: Service
     resources:
-      cpu: 200
-      memory: 800
+      limits:
+        cpu: 200
+        memory: 800
       replicas: 1
     variables:
       - name: input

--- a/docs/local-development/local-secrets.md
+++ b/docs/local-development/local-secrets.md
@@ -65,14 +65,14 @@ Updating secrets ...
 
 ## Step 3: Verify the `quix.yaml` and `.secrets` Files
 
-After running the update command, verify that the `quix.yaml` file now includes the secret key. The key is linked to your secret and referenced by the relevant deployment:
+After running the update command, verify that the `quix.yaml` file now references the secret through its `variableKey`. This key links to your secret value and is used by the relevant deployment:
 
-```yaml title="quix.yaml" hl_lines="21"
+```yaml title="quix.yaml" hl_lines="22 23"
 # Quix Project Descriptor
 # This file describes the data pipeline and configuration of resources of a Quix Project.
 
 metadata:
-  version: 1.0
+  version: 2.0
 
 # This section describes the Deployments of the data pipeline
 deployments:
@@ -81,15 +81,21 @@ deployments:
     version: latest
     deploymentType: Service
     resources:
-      cpu: 200
-      memory: 800
+      limits:
+        cpu: 200
+        memory: 800
       replicas: 1
     variables:
       - name: api_secret_token
-        inputType: Secret
+        inputType: ProjectVariable
         required: false
-        secretKey: api_secret_token_key
+        secret: true
+        variableKey: api_secret_token_key
 ```
+
+!!! note "Secrets are project variables"
+
+    A secret is stored as a `ProjectVariable` with `secret: true`, referenced by `variableKey`. (The older `inputType: Secret` + `secretKey` form is still accepted but normalized to this shape on save.) See [YAML 1.0 and 2.0](../../quix-cloud/projects/yaml-2-0.md) and [Project variables](../../quix-cloud/deployments/project-variables.md) for the full model.
 
 Additionally, a `.secrets` file is generated or updated with the actual value associated with the secret key:
 
@@ -108,14 +114,14 @@ api_secret_token_key=SECRET-API-TOKEN-VALUE
 
 ## Step 4: Reuse Secrets Across Multiple Deployments
 
-To use the same secret across multiple deployments, reference the same `secretKey` in different deployments within your `quix.yaml` file. For example:
+To use the same secret across multiple deployments, reference the same `variableKey` in different deployments within your `quix.yaml` file. For example:
 
-```yaml title="quix.yaml" hl_lines="21 35"
+```yaml title="quix.yaml" hl_lines="23 39"
 # Quix Project Descriptor
 # This file describes the data pipeline and configuration of resources of a Quix Project.
 
 metadata:
-  version: 1.0
+  version: 2.0
 
 # This section describes the Deployments of the data pipeline
 deployments:
@@ -124,28 +130,32 @@ deployments:
     version: latest
     deploymentType: Service
     resources:
-      cpu: 200
-      memory: 800
+      limits:
+        cpu: 200
+        memory: 800
       replicas: 1
     variables:
       - name: api_secret_token
-        inputType: Secret
+        inputType: ProjectVariable
         required: false
-        secretKey: api_secret_token_key
+        secret: true
+        variableKey: api_secret_token_key
 
   - name: other-deployment
     application: other-application
     version: latest
     deploymentType: Service
     resources:
-      cpu: 200
-      memory: 800
+      limits:
+        cpu: 200
+        memory: 800
       replicas: 1
     variables:
       - name: a_different_variable_name
-        inputType: Secret
+        inputType: ProjectVariable
         required: false
-        secretKey: api_secret_token_key
+        secret: true
+        variableKey: api_secret_token_key
 ```
 
 In this setup, both `starter-source` and `other-deployment` use the same secret key (`api_secret_token_key`), even though they reference it with different variable names (`api_secret_token` and `a_different_variable_name`). This ensures consistency across deployments and reduces redundancy.

--- a/docs/local-development/local-yaml-variables.md
+++ b/docs/local-development/local-yaml-variables.md
@@ -38,8 +38,9 @@ Here’s an example:
 
 ```yaml
 resources:
-  cpu: {{CPU}}
-  memory: {{RAM}}
+  limits:
+    cpu: {{CPU}}
+    memory: {{RAM}}
   replicas: {{REPLICAS}}
 
 # This section describes the Topics of the data pipeline

--- a/docs/yaml-reference/app-descriptor.md
+++ b/docs/yaml-reference/app-descriptor.md
@@ -31,8 +31,9 @@ variables:
     defaultValue: enriched-click-data
     required: true
   - name: webhook_url
-    inputType: Secret
+    inputType: ProjectVariable
     description: The webhook url to send notifications to
+    secret: true
     defaultValue: webhook_url
     required: true
   - name: timeout
@@ -67,13 +68,15 @@ variables:
   
     - `OutputTopic`: Refers to a topic where the application will produce data.
 
-    - `Secret`: Refers to a sensitive piece of information, such as API keys or webhook URLs, that needs to be securely handled.
-     
     - `FreeText`: A flexible text input that can be used for various settings or parameters.
 
-    - `HiddenText`: A sensitive text input that should not be displayed in the UI.
+    - `HiddenText`: A text input masked in the UI. It is not a managed secret — use `ProjectVariable` with `secret: true` for sensitive values.
 
     - `Options`: A selection from a predefined list of values. Requires an `options` array where each entry has a `label` (display text) and `value` (actual value).
+
+    - `ProjectVariable`: A value looked up from the project's variables store, resolved per environment. Set `secret: true` to store a sensitive value such as an API key or webhook URL — the modern replacement for the legacy `Secret` type.
+
+    - `VariableGroup`: A reference to an organization-level variable group; the group's variables are injected together at deploy time.
 
 - **options:** An array of predefined choices, required when `inputType` is `Options`. Each entry contains:
   - **label:** The human-readable text displayed in the UI dropdown.
@@ -84,6 +87,8 @@ variables:
 - **defaultValue:** The default value assigned to the variable. This value will be used unless explicitly overridden during deployment.
 
 - **required:** A boolean value indicating whether this variable is mandatory (`true`) or optional (`false`) for the application's operation.
+
+- **secret:** When `true` (with `inputType: ProjectVariable`), the value is treated as sensitive — encrypted at rest and masked in the UI.
 
 ### 3. Docker and Entry Points
 
@@ -130,7 +135,7 @@ Changes to the `app.yaml` file should be made thoughtfully, as they can affect a
 
 - **Consistent Naming:** Ensure that variable names are clear and descriptive to avoid confusion during deployment.
 
-- **Security:** Handle `Secret` type variables with care to ensure sensitive information is not exposed.
+- **Security:** Store sensitive values as a `ProjectVariable` with `secret: true` so they are encrypted and masked, rather than as plain text.
 
 - **Documentation:** Keep the `description` field updated to accurately reflect the purpose and usage of each variable.
 

--- a/docs/yaml-reference/pipeline-descriptor.md
+++ b/docs/yaml-reference/pipeline-descriptor.md
@@ -8,16 +8,24 @@ The `quix.yaml` file serves as the Infrastructure as Code (IaC) descriptor for a
 
 ```yaml
 metadata:
-  version: 1.0
+  version: 2.0
 ```
 
-The `metadata` section contains basic information about the file itself, such as the version of the schema being used. This versioning ensures compatibility and helps manage changes to the structure of the `quix.yaml` file over time.
+The `metadata` section contains basic information about the file itself, such as the descriptor version. The version controls which platform capabilities apply to the file.
+
+!!! tip "Use descriptor version 2.0"
+
+    Two descriptor versions exist: **1.0** and **2.0**. Always use **2.0** to get the full capabilities of the platform — most importantly, deployments inherit their variables from each application's `app.yaml` instead of repeating them in `quix.yaml`. See [YAML 1.0 and 2.0](../../quix-cloud/projects/yaml-2-0.md) for the inheritance model and how to migrate from 1.0.
 
 ---
 
 ## 2. Deployments
 
 The `deployments` section is where you define each component of your data pipeline. Each deployment represents an application or service that performs a specific role in the pipeline, such as a source, transformation, or sink.
+
+!!! info "Version 2.0: most of this is inherited, not written by hand"
+
+    The examples and field references on this page show each deployment in **full**, for reference. Under [descriptor version 2.0](../../quix-cloud/projects/yaml-2-0.md), a deployment **inherits** its variables — and any property left at the application default — from the application's `app.yaml`. You do **not** repeat them in `quix.yaml`: a deployment lists a variable only to **override** it for that deployment, and a deployment that overrides nothing has no `variables:` block at all. The complete shape shown here is what the platform **resolves at deploy time**; what you actually write is usually much smaller. See [YAML 1.0 and 2.0](../../quix-cloud/projects/yaml-2-0.md) for what you write versus what the platform computes.
 
 ### Example
 
@@ -29,8 +37,9 @@ deployments:
     version: latest
     group: data-sources
     resources:
-      cpu: 200
-      memory: 500
+      limits:
+        cpu: 200
+        memory: 500
       replicas: 1
     desiredStatus: Running
     workspaceIds:
@@ -44,18 +53,20 @@ deployments:
         value: csv-data
         multiline: false
       - name: api_key
-        inputType: Secret
+        inputType: ProjectVariable
         description: API key for data source
         required: true
-        secretKey: data-source-api-key
+        secret: true
+        variableKey: data-source-api-key
     disabled: true
   - name: data-visualizer
     application: data-visualizer
     version: latest
     deploymentType: Service
     resources:
-      cpu: 500
-      memory: 1000
+      limits:
+        cpu: 500
+        memory: 1000
       replicas: 1
     publicAccess:
       enabled: true
@@ -96,8 +107,9 @@ deployments:
     image: custom-repo/my-service:1.2.3
     deploymentType: Service
     resources:
-      cpu: 300
-      memory: 600
+      limits:
+        cpu: 300
+        memory: 600
       replicas: 2
     desiredStatus: Running
   - name: Dynamic Configuration Manager
@@ -169,10 +181,12 @@ deployments:
 
 #### Resources Fields
 
+The `resources` object nests `cpu` and `memory` under a `limits` key; `replicas` sits alongside `limits`:
+
 | Field | Required | Type | Examples | Description & Notes |
 |-------|----------|------|----------|---------------------|
-| `cpu` | No | integer | `200`, `500`, `1000` | Millicores requested. |
-| `memory` | No | integer | `256`, `512`, `1024` | Memory request in MB. Monitor usage to adjust. |
+| `limits.cpu` | No | integer | `200`, `500`, `1000` | Millicores requested. |
+| `limits.memory` | No | integer | `256`, `512`, `1024` | Memory request in MB. Monitor usage to adjust. |
 | `replicas` | No | integer | `1`, `2`, `3` | The number of instances of the application to run for scalability and fault tolerance. |
 
 #### Public Access Fields
@@ -205,18 +219,24 @@ deployments:
 
 #### Variable Fields
 
+!!! info "Under version 2.0 these are usually inherited"
+
+    These fields define a deployment variable in full, but under [descriptor version 2.0](../../quix-cloud/projects/yaml-2-0.md) you declare them once in the application's `app.yaml` and each deployment inherits them. In `quix.yaml` you set a field here only to **override** the application default for that deployment.
+
 | Field | Required | Type | Examples | Description & Notes |
 |-------|----------|------|----------|---------------------|
 | `name` | Yes | string | `input`, `output`, `api_key` | The name of the variable. |
-| `inputType` | Yes | enum | `InputTopic`, `OutputTopic`, `Secret`, `FreeText`, `Options`, `HiddenText` | Determines validation & UI control type. The available options for `Options` type are defined in `app.yaml`. |
+| `inputType` | Yes | enum | `InputTopic`, `OutputTopic`, `FreeText`, `HiddenText`, `Options`, `ProjectVariable`, `VariableGroup` | Determines validation & UI control type. The list for `Options` is defined in `app.yaml`. (`Secret` is a legacy type, normalized to `ProjectVariable` + `secret: true` — see the note below.) |
 | `description` | No | string | Free text | A brief explanation of what this variable does. |
 | `required` | No | boolean | `true` / `false` | Enforces presence of value (or secret) to start deployment. |
-| `value` | No | string | `csv-data` | Assigned value (not for secrets). |
+| `value` | No | string | `csv-data` | Assigned value (not for project variables or secrets). |
+| `variableKey` | When `inputType=ProjectVariable` | string | `data-source-api-key` | Key looked up in the project variables store. Used for `ProjectVariable`, including secrets (with `secret: true`). |
+| `secret` | No | boolean | `true` / `false` | Marks a `ProjectVariable` value as sensitive — encrypted at rest and masked in the UI. |
 | `multiline` | No | boolean | `true` | Enable multi-line editing (mostly with `FreeText`). |
-| `secretKey` | When `inputType=Secret` | string | `data-source-api-key` | Reference to stored secret; secret value not stored here. |
+| `secretKey` | Legacy | string | `data-source-api-key` | **Legacy.** Secret reference for the old `inputType: Secret`. Superseded by `ProjectVariable` + `variableKey` + `secret: true`; normalized away on save. |
 
 !!! note "Secrets"
-    When `inputType: Secret`, supply the reference using `secretKey` (do not put the secret in `value`).
+    Declare a secret as a `ProjectVariable` with `secret: true`, and reference its key with `variableKey` (do not put the secret in `value`). The older `inputType: Secret` + `secretKey` form is still accepted but is normalized to this shape on save.
 
 ### Notes on Docker Image Deployments
 


### PR DESCRIPTION
Add a tip to the pipeline descriptor reference explaining 1.0 vs 2.0 and recommending 2.0, linking to the Quix Cloud YAML 2.0 page.